### PR TITLE
Fixed issue #58

### DIFF
--- a/tkintertable/Tables.py
+++ b/tkintertable/Tables.py
@@ -2220,7 +2220,7 @@ class TableCanvas(Canvas):
     def importTable(self):
         self.importCSV()
 
-    def importCSV(self, filename=None):
+    def importCSV(self, filename=None, sep=','):
         """Import from csv file"""
 
         if filename is None:


### PR DESCRIPTION
Issue #58: unexpected keyword argument 'sep'

Fixed by adding additional argument (sep = ',') to the importCSV function thereby resolving the issue and allowing people to import CSV file with custom separators.