### PR TITLE
Change for ExportTableData method from Tables_IO

### DIFF
--- a/tkintertable/Tables_IO.py
+++ b/tkintertable/Tables_IO.py
@@ -150,7 +150,9 @@ class TableExporter:
 
     def ExportTableData(self, table, sep=None):
         """Export table data to a comma separated file"""
-
+        
+        import platform
+        
         parent=table.parentframe
         filename = filedialog.asksaveasfilename(parent=parent,defaultextension='.csv',
                                                   filetypes=[("CSV files","*.csv")] )
@@ -158,7 +160,10 @@ class TableExporter:
             return
         if sep == None:
             sep = ','
-        writer = csv.writer(open(filename, "w"), delimiter=sep)
+        if platform.system() == "Windows":
+            writer = csv.writer(open(filename, "w", newline=""), delimiter=sep)
+        else: 
+            writer = csv.writer(open(filename, "w"), delimiter=sep)
         model=table.getModel()
         recs = model.getAllCells()
         #take column labels as field names

--- a/tkintertable/Tables_IO.py
+++ b/tkintertable/Tables_IO.py
@@ -147,8 +147,9 @@ class TableExporter:
         """Provides export utility methods for the Table and Table Model classes"""
 
         return
-
-    def ExportTableData(self, table, sep=None):
+    
+    @staticmethod
+    def ExportTableData(table, sep=None):
         """Export table data to a comma separated file"""
         
         import platform


### PR DESCRIPTION
A small modification to avoid creating blank records by Windows during export of a table to csv. Furthermore I changed method ExportTableData to staticmethod as it doesn't actually use an object created by a class. We can just use TableExporter.ExportTableData(table) without creating an object.