### PR TITLE
Fixed some bugs about "plot options"

### DIFF
--- a/tkintertable/Plot.py
+++ b/tkintertable/Plot.py
@@ -24,10 +24,10 @@ import sys, os
 import copy
 try:
     from tkinter import *
-    from tkinter.ttk import *
+#     from tkinter.ttk import *
 except:
     from Tkinter import *
-    from ttk import *
+#     from ttk import *
 if (sys.version_info > (3, 0)):
     from tkinter import filedialog, messagebox, simpledialog
 else:

--- a/tkintertable/Tables.py
+++ b/tkintertable/Tables.py
@@ -1488,7 +1488,7 @@ class TableCanvas(Canvas):
         """Call pylab plot dialog setup, send data if we haven't already
             plotted"""
 
-        from PylabPlot import pylabPlotter
+        from .Plot import pylabPlotter
         if not hasattr(self, 'pyplot'):
             self.pyplot = pylabPlotter()
         plotdata = self.getSelectionValues()


### PR DESCRIPTION
Fixed an error where "plot options" could not be opened
Pylabplot library does not exist, use Tkinter table Plot library overrides
Fixed the error of incomplete display of "plot options"
The TTK library does not support the "- relief" option, so some contents cannot be displayed. Therefore, the TTK library is disabled and the TK library is used